### PR TITLE
Use maven for version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4 - 08/18/2021
+
+- Use `mvn` to detect project version instead of `grep`
+
 ## v3 - 04/10/2021
 
 - Add `version` output

--- a/get-version.sh
+++ b/get-version.sh
@@ -1,1 +1,1 @@
-cat $POMPATH/pom.xml | grep "<version>.*</version>" | head -1 | awk -F'[><]' '{print $3}'
+cd $POMPATH && mvn help:evaluate -Dexpression=project.version -q -DforceStdout


### PR DESCRIPTION
Changes proposed in this merge request:

- Updates: Use mvn instead of grep to pull the current version number


### Pre-merge Checklist

- [x] Update documentation
- [x] Update CHANGELOG and increment version
