### PR TITLE
needed ability to set the release type without using commit comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A simple GitHub Actions to bump the version of Maven projects.
 When triggered, this action will look at the commit message of HEAD~1 and determine if it contains one of `#major`, `#minor`, or `#patch` (in that order of precedence).
 If true, it will use Maven to bump your pom's version.
 
+You can override this default behavior by setting a release type, setting type will override the above commit message check.
+
 For example, a `#minor` update to version `1.3.9` will result in the version changing to `1.4.0`.
 The change will then be committed.
 
@@ -39,6 +41,7 @@ jobs:
 * `github-token`: The only required argument. Can either be the default token, as seen above, or a personal access token with write access to the repository
 * `git-email`: The email address each commit should be associated with. Defaults to a github provided noreply address
 * `git-username`: The GitHub username each commit should be associated with. Defaults to `github-actions[bot]`
+* `type`: This will overide the release type this can  be minor, patch or major. if not set will use comments.
 * `pom-path`: The path within your directory the pom.xml you intended to change is located.
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'The relative location of your pom.xml file'
     required: true
     default: '.'
+  type:
+    description: 'The type of release patch,major, or minor'
+    required: false
+    default: ''
   git-email:
     description: 'The email address used to create the version bump commit with.'
     required: true
@@ -39,6 +43,7 @@ runs:
         EMAIL: ${{ inputs.git-email }}
         NAME: ${{ inputs.git-username }}
         POMPATH: ${{ inputs.pom-path }}
+        TYPE: ${{ inputs.type }}
       run: ${{github.action_path}}/version-bump.sh
       shell: bash
     - name: Set outputs

--- a/version-bump.sh
+++ b/version-bump.sh
@@ -35,19 +35,34 @@ git config --global user.email $EMAIL
 git config --global user.name $NAME
 
 OLD_VERSION=$($DIR/get-version.sh)
-
 BUMP_MODE="none"
-if git log -1 | grep -q "#major"; then
+
+if [[ "${TYPE}" == "" ]]
+then
+  if git log -1 | grep -q "#major"; then
   BUMP_MODE="major"
-elif git log -1 | grep -q "#minor"; then
+  elif git log -1 | grep -q "#minor"; then
   BUMP_MODE="minor"
-elif git log -1 | grep -q "#patch"; then
+  elif git log -1 | grep -q "#patch"; then
   BUMP_MODE="patch"
+  fi
+else
+  case "$TYPE" in
+    major)
+      BUMP_MODE="major"
+      ;;
+    minor)
+      BUMP_MODE="minor"
+      ;;
+    patch)
+      BUMP_MODE="patch"
+      ;;
+    esac
 fi
 
 if [[ "${BUMP_MODE}" == "none" ]]
 then
-  echo "No matching commit tags found."
+  echo "No matching commit tags found or no release type set."
   echo "pom.xml at" $POMPATH "will remain at" $OLD_VERSION
 else
   echo $BUMP_MODE "version bump detected"

--- a/version-bump.sh
+++ b/version-bump.sh
@@ -68,7 +68,7 @@ else
   echo $BUMP_MODE "version bump detected"
   bump $BUMP_MODE $OLD_VERSION
   echo "pom.xml at" $POMPATH "will be bumped from" $OLD_VERSION "to" $NEW_VERSION
-  mvn -q versions:set -DnewVersion="${NEW_VERSION}"
+  mvn --file $POMPATH/pom.xml -q versions:set -DnewVersion="${NEW_VERSION}"
   git add $POMPATH/pom.xml
   REPO="https://$GITHUB_ACTOR:$TOKEN@github.com/$GITHUB_REPOSITORY.git"
   git commit -m "Bump pom.xml from $OLD_VERSION to $NEW_VERSION"


### PR DESCRIPTION
Changes proposed in this merge request:
Created new action input called type, this is the release type.
The input is not required
Updated version-bump.sh to use TYPE environment variable to override
the default check and use TYPE instead of its major, minor, or patch.

I also updated the README file with the new feature.

