### PR TITLE
update deprecated set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
       shell: bash
       env:
         POMPATH: ${{ inputs.pom-path }}
-      run: echo "::set-output name=version::$(${{github.action_path}}/get-version.sh)"
+      run: echo "version=$(${{github.action_path}}/get-version.sh)" >> $GITHUB_OUTPUT
     - name: Result
       shell: bash
       run: "echo 'Version is now ${{ steps.get-outputs.outputs.version }}'"


### PR DESCRIPTION
Changes proposed in this merge request:
- Additions:
- Updates: Instead of using the `::set-output` command, it now writes the version number directly to the `GITHUB_OUTPUT` environment variable in the`action.yml` file
- Deletions:

fixes #12 
